### PR TITLE
Fixed a typo of 'deafult' to 'default'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,6 @@ aws:
       file: /var/log/syslog
       datetime_format: "%b %d %H:%M:%S"
       buffer_duration: 5000
-      log_stream_name: "{{ InstanceID |deafult('') }}"
+      log_stream_name: "{{ InstanceID |default('') }}"
       initial_position: start_of_file
       log_group_name: /var/log/syslog


### PR DESCRIPTION
This resolves a typo in https://github.com/Aplyca/ansible-role-aws/blob/master/defaults/main.yml#L7